### PR TITLE
removed makemigrations command

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,11 +67,6 @@
 
 # Database Migrations
 
-- name: Django Make Migrations
-  django_manage:
-    command: makemigrations --noinput
-    app_path: "{{ csdt_django_git_destination }}"
-    virtualenv: "/opt/{{ csdt_django_app_name }}"
 - name: Django Database Migrations
   django_manage:
     command: migrate


### PR DESCRIPTION
@SillyInventor This PR removes the delete-migrations task in the ansible playbook. Since we agreed to remove this ability from the post-deploy script, I think it would also be appropriate to remove this from the main playbook too.  
  
Do you agree?